### PR TITLE
Add stub for a QueryableCourseMate

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.coursemate.Email;
 import seedu.address.model.coursemate.Name;
 import seedu.address.model.coursemate.Phone;
+import seedu.address.model.coursemate.QueryableCourseMate;
 import seedu.address.model.skill.Skill;
 
 /**
@@ -104,5 +105,23 @@ public class ParserUtil {
             skillSet.add(parseSkill(skillName));
         }
         return skillSet;
+    }
+
+    /**
+     * Parses {@code String label} into a {@code QueryableCourseMate}.
+     */
+    public static QueryableCourseMate parseQueryableCourseMate(String label) throws ParseException {
+        requireNonNull(label);
+        String trimmedLabel = label.trim();
+
+        if (trimmedLabel.isEmpty()) {
+            throw new ParseException("the query cannot be empty");
+        }
+
+        if (trimmedLabel.charAt(0) == '#') {
+            return new QueryableCourseMate(parseIndex(trimmedLabel.substring(1)));
+        } else {
+            return new QueryableCourseMate(parseName(trimmedLabel));
+        }
     }
 }

--- a/src/main/java/seedu/address/model/ContactList.java
+++ b/src/main/java/seedu/address/model/ContactList.java
@@ -134,6 +134,15 @@ public class ContactList implements ReadOnlyContactList {
     }
 
     /**
+     * Finds a {@code CourseMate} with the exact same name.
+     */
+    public CourseMate findCourseMate(Name name) {
+        requireNonNull(name);
+
+        return courseMates.findCourseMate(name);
+    }
+
+    /**
      * Removes {@code key} from this {@code ContactList}.
      * {@code key} must exist in the contact list.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.coursemate.CourseMate;
+import seedu.address.model.coursemate.QueryableCourseMate;
 import seedu.address.model.group.Group;
 
 /**
@@ -77,6 +78,11 @@ public interface Model {
      * existing courseMate in the contact list.
      */
     void setCourseMate(CourseMate target, CourseMate editedCourseMate);
+
+    /**
+     * Finds a {@code CourseMate} with the exact same name.
+     */
+    CourseMate findCourseMate(QueryableCourseMate query);
 
     /** Returns an unmodifiable view of the filtered courseMate list */
     ObservableList<CourseMate> getFilteredCourseMateList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,8 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.coursemate.CourseMate;
+import seedu.address.model.coursemate.QueryableCourseMate;
+import seedu.address.model.coursemate.exceptions.CourseMateNotFoundException;
 import seedu.address.model.group.Group;
 
 /**
@@ -114,6 +116,16 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedCourseMate);
 
         contactList.setCourseMate(target, editedCourseMate);
+    }
+
+    @Override
+    public CourseMate findCourseMate(QueryableCourseMate query) {
+        // EVENTUALLY CHANGE TO HANDLE
+        if (query.isIndex()) {
+            throw new CourseMateNotFoundException();
+        } else {
+            return contactList.findCourseMate(query.getName());
+        }
     }
 
     //=========== Filtered CourseMate List Accessors =============================================================

--- a/src/main/java/seedu/address/model/coursemate/QueryableCourseMate.java
+++ b/src/main/java/seedu/address/model/coursemate/QueryableCourseMate.java
@@ -1,0 +1,69 @@
+package seedu.address.model.coursemate;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.coursemate.exceptions.IllegalQueryableParameterException;
+
+/**
+ * Class that can represent either an index or a name.
+ * This is used to query a CourseMate from a list.
+ */
+public class QueryableCourseMate {
+    private final Index index;
+    private final Name name;
+
+    /**
+     * Basic constructor that takes an {@code Index} object.
+     */
+    public QueryableCourseMate(Index index) {
+        requireNonNull(index);
+        this.index = index;
+        this.name = null;
+    }
+
+    /**
+     * Basic constructor that takes an {@code Name} object.
+     */
+    public QueryableCourseMate(Name name) {
+        requireNonNull(name);
+        this.index = null;
+        this.name = name;
+    }
+
+    /**
+     * Attempts to access this object as an index.
+     * Throws a {@code IllegalQueryableParameterException} if it can't be done.
+     */
+    public Index getIndex() throws IllegalQueryableParameterException {
+        if (index == null) {
+            throw new IllegalQueryableParameterException("Index");
+        }
+        return index;
+    }
+
+    /**
+     * Attempts to access this object as a name.
+     * Throws a {@code IllegalQueryableParameterException} if it can't be done.
+     */
+    public Name getName() throws IllegalQueryableParameterException {
+        if (name == null) {
+            throw new IllegalQueryableParameterException("Name");
+        }
+        return name;
+    }
+
+    /**
+     * Checks if the value is a {@code Index}. Mutually exclusive with {@code isName}.
+     */
+    public boolean isIndex() {
+        return index != null;
+    }
+
+    /**
+     * Checks if the value is a {@code Name}. Mutually exclusive with {@code isIndex}.
+     */
+    public boolean isName() {
+        return name != null;
+    }
+}

--- a/src/main/java/seedu/address/model/coursemate/UniqueCourseMateList.java
+++ b/src/main/java/seedu/address/model/coursemate/UniqueCourseMateList.java
@@ -54,6 +54,22 @@ public class UniqueCourseMateList implements Iterable<CourseMate> {
     }
 
     /**
+     * Finds a courseMate in the list.
+     * The courseMate must already exist in the list. Throws an exception otherwise.
+     */
+
+    public CourseMate findCourseMate(Name name) {
+        requireNonNull(name);
+        for (CourseMate courseMate: internalList) {
+            if (courseMate.getName().equals(name)) {
+                return courseMate;
+            }
+        }
+
+        throw new CourseMateNotFoundException();
+    }
+
+    /**
      * Replaces the courseMate {@code target} in the list with {@code editedCourseMate}.
      * {@code target} must exist in the list.
      * The courseMate identity of {@code editedCourseMate}

--- a/src/main/java/seedu/address/model/coursemate/exceptions/IllegalQueryableParameterException.java
+++ b/src/main/java/seedu/address/model/coursemate/exceptions/IllegalQueryableParameterException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.coursemate.exceptions;
+
+public class IllegalQueryableParameterException extends RuntimeException {
+    public IllegalQueryableParameterException() {
+        super("The QueryableCourseMate is of another type than the accessed type");
+    }
+
+    public IllegalQueryableParameterException(String wrongType) {
+        super(String.format("The QueryableCourseMate is of not of type: %s", wrongType));
+    }
+}

--- a/src/main/java/seedu/address/model/coursemate/exceptions/IllegalQueryableParameterException.java
+++ b/src/main/java/seedu/address/model/coursemate/exceptions/IllegalQueryableParameterException.java
@@ -1,5 +1,8 @@
 package seedu.address.model.coursemate.exceptions;
 
+/**
+ * Signals that a QueryableCourseMate was used as the wrong type.
+ */
 public class IllegalQueryableParameterException extends RuntimeException {
     public IllegalQueryableParameterException() {
         super("The QueryableCourseMate is of another type than the accessed type");

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyContactList;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.coursemate.CourseMate;
+import seedu.address.model.coursemate.QueryableCourseMate;
 import seedu.address.model.group.Group;
 import seedu.address.testutil.CourseMateBuilder;
 
@@ -145,6 +146,10 @@ public class AddCommandTest {
 
         @Override
         public void setCourseMate(CourseMate target, CourseMate editedCourseMate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override public CourseMate findCourseMate(QueryableCourseMate queryableCourseMate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -168,4 +168,26 @@ public class ParserUtilTest {
 
         assertEquals(expectedSkillSet, actualSkillSet);
     }
+
+    @Test
+    public void parseQueryableCourseMate_emptyString_throwsError() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseQueryableCourseMate(""));
+    }
+
+    @Test
+    public void parseQueryableCourseMate_garbageIndex_throwsError() {
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseQueryableCourseMate("#ABC"));
+    }
+
+    @Test
+    public void parseQueryableCourseMate_normalIndex_returnsIndexQueryableCourseMate() throws Exception {
+        assertTrue(ParserUtil.parseQueryableCourseMate("#123").isIndex());
+    }
+
+    @Test
+    public void parseQueryableCourseMate_normalName_returnsNameQueryableCourseMate() throws Exception {
+        assertTrue(ParserUtil.parseQueryableCourseMate("John Doe").isName());
+    }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -100,14 +100,14 @@ public class ModelManagerTest {
 
     @Test
     public void findCourseMate_byNameCourseMateNotInContactList_throwsError() {
-        assertThrows(RuntimeException.class,
-                () -> modelManager.findCourseMate(new QueryableCourseMate(new Name("RANDOM_STRING_12KAJ@"))));
+        assertThrows(RuntimeException.class, () ->
+                modelManager.findCourseMate(new QueryableCourseMate(new Name("RANDOM_STRING_12KAJ@"))));
     }
 
     @Test
     public void findCourseMate_byIndexCourseMateNotInContactList_throwsError() {
-        assertThrows(RuntimeException.class,
-                () -> modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(0))));
+        assertThrows(RuntimeException.class, () ->
+                modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(0))));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -15,7 +16,10 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.coursemate.ContainsKeywordPredicate;
+import seedu.address.model.coursemate.Name;
+import seedu.address.model.coursemate.QueryableCourseMate;
 import seedu.address.testutil.ContactListBuilder;
 
 public class ModelManagerTest {
@@ -86,6 +90,24 @@ public class ModelManagerTest {
     public void hasCourseMate_courseMateInContactList_returnsTrue() {
         modelManager.addCourseMate(ALICE);
         assertTrue(modelManager.hasCourseMate(ALICE));
+    }
+
+    @Test
+    public void findCourseMate_byNameCourseMateInContactList_doesNotThrow() {
+        modelManager.addCourseMate(ALICE);
+        assertDoesNotThrow(() -> modelManager.findCourseMate(new QueryableCourseMate(ALICE.getName())));
+    }
+
+    @Test
+    public void findCourseMate_byNameCourseMateNotInContactList_throwsError() {
+        assertThrows(RuntimeException.class,
+                () -> modelManager.findCourseMate(new QueryableCourseMate(new Name("RANDOM_STRING_12KAJ@"))));
+    }
+
+    @Test
+    public void findCourseMate_byIndexCourseMateNotInContactList_throwsError() {
+        assertThrows(RuntimeException.class,
+                () -> modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(0))));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
+++ b/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
@@ -1,0 +1,46 @@
+package seedu.address.model.coursemate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+
+
+public class QueryableCourseMateTest {
+
+    @Test
+    public void constructor_indexNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new QueryableCourseMate((Index) null));
+    }
+
+    @Test
+    public void constructor_nameNull_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new QueryableCourseMate((Name) null));
+    }
+
+    @Test
+    public void isName_nameObject_returnsTrue() {
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(new Name("John Doe"));
+        assertTrue(queryableCourseMate.isName());
+    }
+
+    @Test
+    public void isIndex_nameObject_returnsFalse() {
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(new Name("John Doe"));
+        assertFalse(queryableCourseMate.isIndex());
+    }
+
+    @Test
+    public void isName_indexObject_returnsFalse() {
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(Index.fromZeroBased(0));
+        assertFalse(queryableCourseMate.isName());
+    }
+
+    @Test
+    public void isIndex_indexObject_returnsFalse() {
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(Index.fromZeroBased(0));
+        assertTrue(queryableCourseMate.isIndex());
+    }
+}

--- a/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
+++ b/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
 
+import seedu.address.commons.core.index.Index;
 
 public class QueryableCourseMateTest {
 

--- a/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
+++ b/src/test/java/seedu/address/model/coursemate/QueryableCourseMateTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.coursemate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -22,8 +23,10 @@ public class QueryableCourseMateTest {
 
     @Test
     public void isName_nameObject_returnsTrue() {
-        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(new Name("John Doe"));
+        Name name = new Name("John Doe");
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(name);
         assertTrue(queryableCourseMate.isName());
+        assertEquals(queryableCourseMate.getName(), name);
     }
 
     @Test
@@ -39,8 +42,10 @@ public class QueryableCourseMateTest {
     }
 
     @Test
-    public void isIndex_indexObject_returnsFalse() {
-        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(Index.fromZeroBased(0));
+    public void isIndex_indexObject_returnsTrue() {
+        Index index = Index.fromZeroBased(0);
+        QueryableCourseMate queryableCourseMate = new QueryableCourseMate(index);
         assertTrue(queryableCourseMate.isIndex());
+        assertEquals(queryableCourseMate.getIndex(), index);
     }
 }

--- a/src/test/java/seedu/address/model/coursemate/UniqueCourseMateListTest.java
+++ b/src/test/java/seedu/address/model/coursemate/UniqueCourseMateListTest.java
@@ -60,12 +60,12 @@ public class UniqueCourseMateListTest {
 
     @Test
     public void findCourseMate_courseMateDoesNotExist_throwsCourseMateNotFoundException() {
-        assertThrows(CourseMateNotFoundException.class,
-                () -> uniqueCourseMateList.findCourseMate(new Name("RANDOM_STRING_AJ124AJK")));
+        assertThrows(CourseMateNotFoundException.class, () ->
+                uniqueCourseMateList.findCourseMate(new Name("RANDOMSTRINGAJ124AJK")));
     }
 
     @Test
-    public void findCourseMate_courseMateExists_CourseMateFound() {
+    public void findCourseMate_courseMateExists_courseMateFound() {
         uniqueCourseMateList.add(ALICE);
         assertDoesNotThrow(() -> uniqueCourseMateList.findCourseMate(ALICE.getName()));
     }

--- a/src/test/java/seedu/address/model/coursemate/UniqueCourseMateListTest.java
+++ b/src/test/java/seedu/address/model/coursemate/UniqueCourseMateListTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.coursemate;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,6 +56,18 @@ public class UniqueCourseMateListTest {
     public void add_duplicateCourseMate_throwsDuplicateCourseMateException() {
         uniqueCourseMateList.add(ALICE);
         assertThrows(DuplicateCourseMateException.class, () -> uniqueCourseMateList.add(ALICE));
+    }
+
+    @Test
+    public void findCourseMate_courseMateDoesNotExist_throwsCourseMateNotFoundException() {
+        assertThrows(CourseMateNotFoundException.class,
+                () -> uniqueCourseMateList.findCourseMate(new Name("RANDOM_STRING_AJ124AJK")));
+    }
+
+    @Test
+    public void findCourseMate_courseMateExists_CourseMateFound() {
+        uniqueCourseMateList.add(ALICE);
+        assertDoesNotThrow(() -> uniqueCourseMateList.findCourseMate(ALICE.getName()));
     }
 
     @Test


### PR DESCRIPTION
QueryableCourseMate represents either an `Index` or a `Name`. It can be queried via `Model::findCourseMate(QueryableCourseMate)`

There is no functionality yet for querying via hashtag notation, though it will be parsed properly into an index.