### PR TITLE
Fix exception in add-member and delete-member

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,7 +13,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_COURSE_MATE_NAME = "The courseMate name provided is not found!";
+    public static final String MESSAGE_INVALID_COURSE_MATE_NAME = "The courseMate name or index provided is not found!";
     public static final String MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX = "The courseMate index provided is invalid";
     public static final String MESSAGE_COURSE_MATES_LISTED_OVERVIEW = "%1$d course mate(s) listed!";
     public static final String MESSAGE_GROUPS_LISTED_OVERVIEW = "%1$d group(s) listed!";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -37,13 +37,8 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<CourseMate> lastShownList = model.getFilteredCourseMateList();
-
-        if (queryableCourseMate.isIndex() && queryableCourseMate.getIndex().getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
-        }
-
         List<CourseMate> courseMateToDeleteList;
+
         try {
             courseMateToDeleteList = model.findCourseMate(queryableCourseMate);
         } catch (CourseMateNotFoundException e) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -70,13 +70,8 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<CourseMate> lastShownList = model.getFilteredCourseMateList();
-
-        if (queryableCourseMate.isIndex() && queryableCourseMate.getIndex().getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
-        }
-
         List<CourseMate> courseMateToEditList;
+
         try {
             courseMateToEditList = model.findCourseMate(queryableCourseMate);
         } catch (CourseMateNotFoundException e) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.coursemate.CourseMate;
 import seedu.address.model.coursemate.Name;
 import seedu.address.model.coursemate.QueryableCourseMate;
@@ -183,6 +185,9 @@ public class ModelManager implements Model {
                 arrayList.add(getRecentlyProcessedCourseMate());
                 return arrayList;
             } else {
+                if (query.isIndex() && query.getIndex().getZeroBased() >= this.getFilteredCourseMateList().size()) {
+                    throw new CourseMateNotFoundException();
+                }
                 ArrayList<CourseMate> arrayList = new ArrayList<>();
                 arrayList.add(getFilteredCourseMateList().get(query.getIndex().getZeroBased()));
                 return arrayList;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,8 +13,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.Messages;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.coursemate.CourseMate;
 import seedu.address.model.coursemate.Name;
 import seedu.address.model.coursemate.QueryableCourseMate;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,8 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX;
-import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.Messages.*;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -65,7 +64,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete #9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INVALID_COURSE_MATE_NAME);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.*;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COURSE_MATE_NAME;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -69,7 +69,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCourseMateList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(new QueryableCourseMate(outOfBoundIndex));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_NAME);
         assertRecentlyProcessedCourseMateEdited(model, null);
     }
 
@@ -109,7 +109,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(new QueryableCourseMate(outOfBoundIndex));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_NAME);
         assertRecentlyProcessedCourseMateEdited(model, null);
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -162,7 +162,7 @@ public class EditCommandTest {
         EditCourseMateDescriptor descriptor = new EditCourseMateDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(new QueryableCourseMate(outOfBoundIndex), descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_NAME);
         assertRecentlyProcessedCourseMateEdited(model, null);
     }
 
@@ -190,7 +190,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(new QueryableCourseMate(outOfBoundIndex),
                 new EditCourseMateDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_COURSE_MATE_NAME);
         assertRecentlyProcessedCourseMateEdited(model, null);
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -109,7 +109,11 @@ public class ModelManagerTest {
     public void findCourseMate_byIndexCourseMateNotInContactList_throwsError() {
         assertThrows(CourseMateNotFoundException.class, () ->
                 modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(0))));
+        modelManager.addCourseMate(ALICE);
+        assertThrows(CourseMateNotFoundException.class, () ->
+                modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(10))));
     }
+
 
     @Test
     public void findCourseMate_byIndexCourseMateInContactList_doesNotThrow() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.coursemate.ContainsKeywordPredicate;
 import seedu.address.model.coursemate.Name;
 import seedu.address.model.coursemate.QueryableCourseMate;
+import seedu.address.model.coursemate.exceptions.CourseMateNotFoundException;
 import seedu.address.testutil.ContactListBuilder;
 
 public class ModelManagerTest {
@@ -106,8 +107,14 @@ public class ModelManagerTest {
 
     @Test
     public void findCourseMate_byIndexCourseMateNotInContactList_throwsError() {
-        assertThrows(RuntimeException.class, () ->
+        assertThrows(CourseMateNotFoundException.class, () ->
                 modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(0))));
+    }
+
+    @Test
+    public void findCourseMate_byIndexCourseMateInContactList_doesNotThrow() {
+        modelManager.addCourseMate(ALICE);
+        assertDoesNotThrow(() -> modelManager.findCourseMate(new QueryableCourseMate(Index.fromZeroBased(-1))));
     }
 
     @Test


### PR DESCRIPTION
May need to modify error messages, as index < 0 is shown as invalid format. The issue is there are a lot of parsing errors possible (Missing input, negative index, etc), so not sure if a specific message or a general one is better.

Close #120 